### PR TITLE
Add support for amp-pixel, amp-anim, fixed layout for small images

### DIFF
--- a/src/AMP.php
+++ b/src/AMP.php
@@ -49,7 +49,7 @@ class AMP
     // The StandardFixPass should be after StandardScanPass
     public $passes = [
         'Lullabot\AMP\Pass\PreliminaryPass', // Removes user blacklisted tags
-        'Lullabot\AMP\Pass\ImgTagTransformPass',
+        'Lullabot\AMP\Pass\SugarImgTagTransformPass',
         'Lullabot\AMP\Pass\IframeSoundCloudTagTransformPass',
         'Lullabot\AMP\Pass\IframeFacebookTagTransformPass',
         'Lullabot\AMP\Pass\AudioTagTransformPass',

--- a/src/Pass/SugarImgTagTransformPass.php
+++ b/src/Pass/SugarImgTagTransformPass.php
@@ -1,0 +1,85 @@
+<?php
+namespace Lullabot\AMP\Pass;
+
+use Lullabot\AMP\Validate\Scope;
+use Lullabot\AMP\Utility\ActionTakenLine;
+use Lullabot\AMP\Utility\ActionTakenType;
+
+use QueryPath\DOMQuery;
+
+/**
+ * Class SugarImgTagTransformPass
+ * @package Lullabot\AMP\Pass
+ *
+ * See docs for ImgTagTransformPass
+ * Additionally: amp-pixel and fixed layout for small images
+ */
+class SugarImgTagTransformPass extends ImgTagTransformPass
+{
+    function pass()
+    {
+        // Always make sure we do this. Somewhat of a hack
+        if ($this->context->getErrorScope() == Scope::HTML_SCOPE) {
+            $this->q->find('html')->attr('amp', '');
+        }
+
+        $all_a = $this->q->top()->find('img:not(noscript img)');
+        /** @var DOMQuery $el */
+        foreach ($all_a as $el) {
+            /** @var \DOMElement $dom_el */
+            $dom_el = $el->get(0);
+            $lineno = $this->getLineNo($dom_el);
+            if ($this->isSvg($dom_el)) {
+                // @TODO This should be marked as a validation warning later?
+                continue;
+            }
+            $context_string = $this->getContextString($dom_el);
+            $this->setResponsiveImgHeightAndWidth($el);
+            if ($el->attr('width') === '1' && $el->attr('height') === '1') {
+                // Convert 1x1 images to amp-pixel tracking tags
+                $new_dom_el = $dom_el->ownerDocument->createElement('amp-pixel');
+                $new_dom_el->setAttribute('src', $el->attr('src'));
+                $dom_el->parentNode->insertBefore($new_dom_el, $dom_el);
+                $success_action_taken_type = ActionTakenType::IMG_PIXEL_CONVERTED;
+            }
+            else {
+                // Convert gif images to amp-anim, other images to amp-img
+                $pathinfo = pathinfo($el->attr('src'));
+
+                if ($pathinfo['extension'] == 'gif') {
+                    $amp_tag = 'amp-anim';
+                    $success_action_taken_type = ActionTakenType::IMG_ANIM_CONVERTED;
+                    $fail_action_taken_type = ActionTakenType::IMG_ANIM_COULD_NOT_BE_CONVERTED;
+                }
+                else {
+                    $amp_tag = 'amp-img';
+                    $success_action_taken_type = ActionTakenType::IMG_CONVERTED;
+                    $fail_action_taken_type = ActionTakenType::IMG_COULD_NOT_BE_CONVERTED;
+                }
+
+                $new_dom_el = $this->cloneAndRenameDomElement($dom_el, $amp_tag);
+                $new_el = $el->prev();
+
+                $success = $this->setResponsiveImgHeightAndWidth($new_el);
+                // We were not able to get the image dimensions, abort conversion.
+                if (!$success) {
+                    $this->addActionTaken(new ActionTakenLine('img', $fail_action_taken_type, $lineno, $context_string));
+                    // Abort the conversion and remove the new img tag
+                    $new_el->remove();
+                    continue;
+                }
+
+                $layout = ($new_el->attr('width') < 300 && $new_el->attr('width') < 300)
+                    ? 'fixed' : 'responsive';
+
+                $this->setLayoutIfNoLayout($new_el, $layout);
+            }
+
+            $this->context->addLineAssociation($new_dom_el, $lineno);
+            $this->addActionTaken(new ActionTakenLine('img', $success_action_taken_type, $lineno, $context_string));
+            $el->remove(); // remove the old img tag
+        }
+
+        return $this->transformations;
+    }
+}

--- a/src/Utility/ActionTakenType.php
+++ b/src/Utility/ActionTakenType.php
@@ -24,6 +24,9 @@ class ActionTakenType
     const PROPERTY_REMOVED = 'property value pair was removed from attribute due to validation issues.';
     const PROPERTY_REMOVED_ATTRIBUTE_REMOVED = 'property value pair was removed from attribute due to validation issues. The resulting attribute was empty and was also removed.';
     const IMG_CONVERTED = 'tag was converted to the amp-img tag.';
+    const IMG_ANIM_CONVERTED = 'tag was converted to the amp-anim tag.';
+    const IMG_ANIM_COULD_NOT_BE_CONVERTED = 'tag could NOT be converted to the amp-anim tag as the image is not accessible.';
+    const IMG_PIXEL_CONVERTED = 'tag was converted to the amp-pixel tag.';
     const IMG_COULD_NOT_BE_CONVERTED = 'tag could NOT be converted to the amp-img tag as the image is not accessible.';
     const INSTAGRAM_CONVERTED = 'instagram embed code was converted to the amp-instagram tag.';
     const PINTEREST_CONVERTED = 'pinterest embed code was converted to the amp-pinterest tag.';

--- a/tests/test-data/fragment-html/img-test-fragment.html.out
+++ b/tests/test-data/fragment-html/img-test-fragment.html.out
@@ -4,7 +4,7 @@
 <amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="625" height="480" layout="responsive"></amp-img>
 
 <!-- should transform to amp-img with responsive layout, preserving the width and height -->
-<amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96" layout="responsive"></amp-img>
+<amp-img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" width="125" height="96" layout="fixed"></amp-img>
 
 <!-- nonexistent image, should refuse to convert to amp-img -->
 <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/non-existent-image1234.jpg">

--- a/tests/test-data/fragment-html/sugar-img-test-fragment.html
+++ b/tests/test-data/fragment-html/sugar-img-test-fragment.html
@@ -1,0 +1,5 @@
+<!-- should transform to amp-pixel -->
+<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" height="1" width="1" />
+
+<!-- should transform to amp-gif -->
+<img src="https://upload.wikimedia.org/wikipedia/commons/b/b7/True_Color_GIF_image-Tc217.gif" />

--- a/tests/test-data/fragment-html/sugar-img-test-fragment.html.out
+++ b/tests/test-data/fragment-html/sugar-img-test-fragment.html.out
@@ -1,0 +1,33 @@
+<!-- should transform to amp-pixel -->
+<amp-pixel src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg"></amp-pixel>
+
+<!-- should transform to amp-gif -->
+<amp-anim src="https://upload.wikimedia.org/wikipedia/commons/b/b7/True_Color_GIF_image-Tc217.gif" width="217" height="217" layout="fixed"></amp-anim>
+
+ORIGINAL HTML
+---------------
+Line 1: <!-- should transform to amp-pixel -->
+Line 2: <img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" height="1" width="1" />
+Line 3: 
+Line 4: <!-- should transform to amp-gif -->
+Line 5: <img src="https://upload.wikimedia.org/wikipedia/commons/b/b7/True_Color_GIF_image-Tc217.gif" />
+
+
+Transformations made from HTML tags to AMP custom tags
+-------------------------------------------------------
+
+<img src="https://upload.wikimedia.org/wikipedia/commons/e/ee/%22Birdcatcher%22_with_jockey_up.jpg" height="1" width="1"> at line 2
+ ACTION TAKEN: img tag was converted to the amp-pixel tag.
+
+<img src="https://upload.wikimedia.org/wikipedia/commons/b/b7/True_Color_GIF_image-Tc217.gif"> at line 5
+ ACTION TAKEN: img tag was converted to the amp-anim tag.
+
+
+AMP-HTML Validation Issues and Fixes
+-------------------------------------
+PASS
+
+COMPONENT NAMES WITH JS PATH
+------------------------------
+'amp-anim', include path 'https://cdn.ampproject.org/v0/amp-anim-0.1.js'
+

--- a/tests/test-data/full-html/noscript.html.out
+++ b/tests/test-data/full-html/noscript.html.out
@@ -50,7 +50,7 @@
     <source src="https://example.com/howl-of-the-lemur.mp3" type="audio/mpeg">
   </amp-audio>
   <!-- Invalid: img must be in a noscript tag -->
-  <amp-img alt="Iconic Lemurs" height="200" src="https://example.com/lemurs.png" width="80" layout="responsive"></amp-img>
+  <amp-img alt="Iconic Lemurs" height="200" src="https://example.com/lemurs.png" width="80" layout="fixed"></amp-img>
   <!-- Invalid: video must be in a noscript tag -->
   <amp-video controls height="480" width="640" layout="responsive">
     <source src="https://example.com/island-of-lemurs.mp4" type="video/mp4">


### PR DESCRIPTION
@casey-powell @mpatnode-si 

This PR adds support for `amp-pixel`, `amp-anim` and `fixed` layouts for smaller images to amp-library.

Corresponding unit tests have been updated and can be run from the repo's root directory:

```
composer install
phpunit --bootstrap ./vendor/autoload.php ./tests/AmpTest.php
```
