### PR TITLE
Add "twitter-video" class to TwitterTransformPass

### DIFF
--- a/src/Pass/TwitterTransformPass.php
+++ b/src/Pass/TwitterTransformPass.php
@@ -30,7 +30,7 @@ class TwitterTransformPass extends BasePass
 {
     function pass()
     {
-        $all_tweets = $this->q->top()->find('blockquote.twitter-tweet');
+        $all_tweets = $this->q->top()->find('blockquote.twitter-tweet, blockquote.twitter-video');
         /** @var DOMQuery $el */
         foreach ($all_tweets as $el) {
             /** @var \DOMElement $dom_el */


### PR DESCRIPTION
This PR adds `twitter-video` to the twitter transform pass selector.

Test: http://popsugar.dev10.onsugar.com/42184740/amp
