### PR TITLE
Fix bug that might cause amp-img "height" attribute missing error

### DIFF
--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -299,7 +299,7 @@ class ImgTagTransformPass extends BasePass
         $wcss = new CssLengthAndUnit($el->attr('width'), false);
         $hcss = new CssLengthAndUnit($el->attr('height'), false);
 
-        if ($wcss->is_set && $wcss->is_valid && $wcss->is_set && $wcss->is_valid && $wcss->unit == $hcss->unit) {
+        if ($wcss->is_set && $wcss->is_valid && $hcss->is_set && $hcss->is_valid && $wcss->unit == $hcss->unit) {
             return true;
         }
 


### PR DESCRIPTION
This PR fixes a bug that sometimes causes a "missing height attribute error" on amp-img tags
