### PR TITLE
Add support for tall pins by specifying height without width (or auto width)

### DIFF
--- a/src/Pass/PinterestTagTransformPass.php
+++ b/src/Pass/PinterestTagTransformPass.php
@@ -93,15 +93,21 @@ class PinterestTagTransformPass extends BasePass
 
         $width = $el->attr('width');
         $height = $el->attr('height');
+
+        if (!empty($height) && empty($width)) {
+            $width = 'auto';
+        }
+
         $hw_available = !empty($width) && !empty($height);
         $new_el->attr('data-pin-width', $pin_width);
         if ($hw_available) {
             $new_el->attr('width', $width);
             $new_el->attr('height', $height);
-        } else {
-            $new_el->attr($dimensions[$pin_width]);
+            $new_el->attr('layout', $width == 'auto' ? 'fixed-height' : 'fixed');
         }
-        // Add responsive so it doesn't look like sh*t
-        $new_el->attr('layout', 'responsive');
+        else {
+            $new_el->attr($dimensions[$pin_width]);
+            $new_el->attr('layout', 'responsive');
+        }
     }
 }


### PR DESCRIPTION
This adds support at this level.   The next step is to use the Pinterest API in our code to automagically detect tall pins.   That's not going to be particularly pretty.