### PR TITLE
Check if an img is a pixel before dismissing it for having no height and width

### DIFF
--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -73,14 +73,14 @@ class ImgTagTransformPass extends BasePass
             $lineno = $this->getLineNo($dom_el);
             $context_string = $this->getContextString($dom_el);
             $has_height_and_width = $this->setResponsiveImgHeightAndWidth($el);
-            if (!$has_height_and_width) {
-                $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_COULD_NOT_BE_CONVERTED, $lineno, $context_string));
-            }
-            elseif ($this->isPixel($el)) {
+            if ($this->isPixel($el)) {
                 $new_dom_el = $this->convertAmpPixel($el, $lineno, $context_string);
             }
             elseif ($this->isAnimation($el)) {
                 $new_dom_el = $this->convertAmpAnim($el, $lineno, $context_string);
+            }
+            else if (!$has_height_and_width) {
+                $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_COULD_NOT_BE_CONVERTED, $lineno, $context_string));
             }
             else {
                 $new_dom_el = $this->convertAmpImg($el, $lineno, $context_string);


### PR DESCRIPTION
https://sugaropslogstash12.sugarops.com/_plugin/kibana/#/doc/logstash-*/logstash-2017.02.01/logs/?id=AVn3VSde8nVk5o5-g-Vh

I fixed that particular post in prod, but it used to have this img tag (note the height/width)
```
<img src="http://ad.doubleclick.net/N5485/ad/sugar.pop/track;adv=efsep131x1;sz=1x1;?" width="0" height="0" border="0" style="display:none;">
```