### PR TITLE
Don't bother transforming broken images

### DIFF
--- a/src/Pass/ImgTagTransformPass.php
+++ b/src/Pass/ImgTagTransformPass.php
@@ -73,14 +73,15 @@ class ImgTagTransformPass extends BasePass
             $lineno = $this->getLineNo($dom_el);
             $context_string = $this->getContextString($dom_el);
             $has_height_and_width = $this->setResponsiveImgHeightAndWidth($el);
-            if ($this->isPixel($el)) {
+            if (!$has_height_and_width) {
+                $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_COULD_NOT_BE_CONVERTED, $lineno, $context_string));
+                continue;
+            }
+            else if ($this->isPixel($el)) {
                 $new_dom_el = $this->convertAmpPixel($el, $lineno, $context_string);
             }
             elseif ($this->isAnimation($el)) {
                 $new_dom_el = $this->convertAmpAnim($el, $lineno, $context_string);
-            }
-            else if (!$has_height_and_width) {
-                $this->addActionTaken(new ActionTakenLine('img', ActionTakenType::IMG_COULD_NOT_BE_CONVERTED, $lineno, $context_string));
             }
             else {
                 $new_dom_el = $this->convertAmpImg($el, $lineno, $context_string);


### PR DESCRIPTION
This is basically a revert of #12 and adding a `continue` to skip broken images.

This will more closely match what's in Lullabot/amp-library, which should have been in this repo to begin with, but I think must have been accidentally omitted.