### PR TITLE
update regex for twitter id to strict version

### DIFF
--- a/src/Pass/TwitterTransformPass.php
+++ b/src/Pass/TwitterTransformPass.php
@@ -140,7 +140,7 @@ class TwitterTransformPass extends BasePass
         foreach ($links as $link) {
             $href = $link->attr('href');
             $matches = [];
-            if (preg_match('&(*UTF8)twitter.com/.*/status(?:es)?/([^/]+)&i', $href, $matches)) {
+            if (preg_match('&(*UTF8)twitter.com/.*/status(?:es)?/(\d+)&i', $href, $matches)) {
                 if (!empty($matches[1])) {
                     $tweet_id = $matches[1];
                     break;


### PR DESCRIPTION
@mpatnode-si 
AMP does not like 
```
<amp-twitter data-lang="en" height="694" width="486" layout="responsive" data-tweetid="913786398238560257?ref_src=twsrc%5Etfw"></amp-twitter>
``` 
those tweetid is bad
```

<amp-twitter data-lang="en" height="694" width="486" layout="responsive" data-tweetid="913786398238560257"></amp-twitter>
```
would be ok