### PR TITLE
fix facebook embeded text posts not show up issue

### DIFF
--- a/src/Pass/SugarFacebookNonIframeTransformPass.php
+++ b/src/Pass/SugarFacebookNonIframeTransformPass.php
@@ -14,9 +14,4 @@ class SugarFacebookNonIframeTransformPass extends FacebookNonIframeTransformPass
     {
         return TRUE;
     }
-
-    protected function isValidVideoUrl($url)
-    {
-        return TRUE;
-    }
 }


### PR DESCRIPTION
@mpatnode-si 

text or photo posts from facebook[data-show-text='false']
can not embed as video post in amp. 

it would not show up. like this:
https://popsugar.dev4.onsugar.com/moms/Family-Color-Coded-Signed-Thanksgiving-Tablecloth-44292611/amp would not show the photo.

but now as we all embed them as videos.
since in FacebookNonIframeTransformPass LINE:114, if we do not add show-text. it would be not happy. 


